### PR TITLE
docs: align spec and README with actual channel/queue names (issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Provide real-time communication and coordination for OpenClaw's sub-agent ecosys
 | `a2a:results:main` | Pub/Sub | Processed results (ResultProcessor output) |
 | `a2a:heartbeats` | Pub/Sub | Worker heartbeat pub/sub |
 | `a2a:registry` | Hash | Persisted agent registry |
-| `coordination:tasks` | List | Task enqueue queue (dispatcher polls) |
+| `coordination:tasks:{high,normal,low}` | List | Priority task queues (dispatcher polls high → normal → low) |
 | `coordination:tasks:dlq` | List | Dead-letter queue for unroutable tasks |
 
 ### 2. Task Queue

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -129,11 +129,16 @@ subscribe('a2a:coordination', callback)
 
 ### 4.2 Queue Operations
 
-**Implementation note:** Priority queues (`tasks:queue:<priority>`) are documented in the spec but not yet implemented. The current implementation uses a single `coordination:tasks` queue with `LPUSH`/`BRPOP`. Priority queue support is tracked as a backlog item.
+Three priority queues are polled in order by `TaskDispatcher` (high → normal → low):
 
-- `LPUSH coordination:tasks <task-json>` — Enqueue (via `taskQueue.enqueue()`)
-- `BRPOP coordination:tasks <timeout>` — Dequeue (via `TaskDispatcher`)
-- `LPUSH tasks:<type> <task-json>` — Typed queue per worker type (coded, github-ops, research, dev-ops)
+| Key | Priority | LPUSH command |
+|-----|----------|---------------|
+| `coordination:tasks:high` | High | `LPUSH coordination:tasks:high <task-json>` |
+| `coordination:tasks:normal` | Normal (default) | `LPUSH coordination:tasks:normal <task-json>` |
+| `coordination:tasks:low` | Low | `LPUSH coordination:tasks:low <task-json>` |
+
+- Enqueue via `scripts/hub-task.js --priority high|normal|low` or `src/task-queue.js`
+- Dequeue via `BRPOP coordination:tasks:{high,normal,low} <timeout>` (dispatcher polls in priority order)
 
 **Dead-letter queue:** Tasks with unknown types are routed to `coordination:tasks:dlq` and a dead-letter result is published to `a2a:results:main`.
 


### PR DESCRIPTION
## Summary

- Updates `TECHNICAL_SPEC.md` §4.2 to document the three priority queues (`coordination:tasks:{high,normal,low}`) and removes the stale "not yet implemented" note
- Updates README channel reference table to replace `coordination:tasks` (singular) with `coordination:tasks:{high,normal,low}`

Closes #22. Also closes #23 (priority queue spec/impl gap — queues are now implemented and documented).

## Test plan

- [ ] Docs-only change — no code touched, no tests needed
- [ ] Channel table in README matches `src/dispatcher.js` queue names

🤖 Generated with [Claude Code](https://claude.com/claude-code)