### PR TITLE
feat: SharedStore cross-agent artifact sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm test                                             # unit tests — no Redis required, fast
+npm run test:integration                             # integration tests — requires live Redis
+npm run test:coverage                                # unit tests + v8 coverage report
+npx vitest run test/unit/<file>.test.js              # single test file
+
+docker exec openclaw-coordination-hub npm test       # preferred in dev (runs inside the container)
+
+npm start                                            # start the hub (requires Redis)
+```
+
+Environment for integration tests: `REDIS_HOST` (default `redis`) and `REDIS_PORT` (default `6379`).
+
+## Architecture
+
+### Task flow
+
+Tasks move through four stages, each implemented in a separate file:
+
+1. **Enqueue** — `scripts/hub-task.js` (or `src/task-queue.js`) LPUSHes to `coordination:tasks:{high,normal,low}`
+2. **Dispatch** — `src/dispatcher.js` BRPOPs from those priority queues, routes by `task.type` → RPUSHes to `a2a:inbox:{agentId}` (RPUSH+BLPOP = FIFO)
+3. **Process** — workers (`workers/*.js`) BLPOP their inbox, call `processTask()`, publish result JSON to `a2a:coordination` pub/sub
+4. **Handle results** — `src/result-processor.js` subscribes to `a2a:coordination`, applies policies from `config/result-policies.json`, re-publishes to `a2a:results:main`
+
+### Worker pattern
+
+All specialist workers extend `BaseWorker` (`workers/base-worker.js`). Subclasses override:
+- `processTask(payload)` — task handler
+- `getCapabilities()` — list of task types this worker handles
+
+For unit tests, inject Redis and SharedStore via constructor options to avoid live connections:
+```js
+new SomeWorker('agent-id', { redis: mockRedis, artifactStore: mockSharedStore })
+```
+
+### Agent registry & liveness
+
+Two Redis structures work together (spans `workers/base-worker.js` ↔ `src/a2a-adapter.js`):
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `a2a:registry` | Hash | `agentId → {status, capabilities, lastSeen, startedAt}` |
+| `a2a:registry:{agentId}:ttl` | Key | TTL sentinel; expires at `heartbeatInterval × 3` seconds |
+
+Both are written by `BaseWorker.register()` and refreshed on every `sendHeartbeat()` tick. When an agent stops, its sentinel expires and `lastSeen` goes stale. `A2AAdapter.syncRegistryFromRedis()` batch-checks all sentinels via MGET and prunes hash fields where the sentinel is gone **and** `lastSeen` exceeds `staleAgentMs` (default 90 000 ms, configurable via constructor option). The hub never prunes itself — it has no sentinel.
+
+### A2A pub/sub channels
+
+| Channel | Transport | Usage |
+|---------|-----------|-------|
+| `a2a:agents` | pub/sub | Broadcast (to=`*`) |
+| `a2a:coordination` | pub/sub | Peer negotiation + worker results |
+| `a2a:inbox:{agentId}` | Redis list | Directed task delivery |
+| `a2a:heartbeats` | pub/sub | Worker heartbeats |
+
+### Optional memory layer
+
+`src/mem0-adapter.js` wraps an external Mem0 service (opt-in: `MEM0_ENABLED=true`). When disabled or unreachable it falls back to `src/memory-bridge.js`, which appends events to `openclaw-memory-system-v1/journal.jsonl`.
+
+### Shared artifacts
+
+`src/shared-store.js` (`SharedStore`) is the cross-agent artifact layer used by all workers. It extends `ArtifactStore` with two additions:
+
+- **`find(query)`** — scan manifests and filter by `{ agentId, tags, taskId, type, filename }`
+- **`artifact_ready` notifications** — on every `writeArtifact()` call, publishes `{ type: 'artifact_ready', artifactId, agentId, filename, tags, taskId }` to the `a2a:agents` broadcast channel (fire-and-forget; requires Redis to be injected via `store.redis = this.redis` after `connect()`)
+
+`A2AAdapter` handles `artifact_ready` messages in `handleBroadcast()` and re-emits them as an `'artifact_ready'` Node.js event for hub/worker subscribers.
+
+Artifacts are stored under `shared/artifacts/` (configurable via `SHARED_ARTIFACT_PATH` env var). Each artifact gets its own directory: `{basePath}/{artifactId}/manifest.json` + the content file.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 ## Completed
 
 ### `shared/` — Cross-agent artifact sharing
-**Status:** Done (merged in feat/shared-cross-agent-store)
+**Status:** Done (introduced in PR #52)
 
 `SharedStore` (`src/shared-store.js`) extends `ArtifactStore` with:
 - `find({ agentId, tags, taskId, type, filename })` — query-based artifact discovery

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,17 @@
+# Coordination Hub Backlog
+
+## Completed
+
+### `shared/` — Cross-agent artifact sharing
+**Status:** Done (merged in feat/shared-cross-agent-store)
+
+`SharedStore` (`src/shared-store.js`) extends `ArtifactStore` with:
+- `find({ agentId, tags, taskId, type, filename })` — query-based artifact discovery
+- Redis pub/sub notification (`artifact_ready` → `a2a:agents`) on every write
+- `A2AAdapter` handles `artifact_ready` and emits it as a Node.js event
+
+Workers use `this.artifacts` (a `SharedStore` instance). Redis is wired in automatically after `connect()`.
+
+## Pending
+
+_No items currently pending._

--- a/src/a2a-adapter.js
+++ b/src/a2a-adapter.js
@@ -10,11 +10,13 @@
  * - Coordination channel for peer negotiation
  * - Agent registry for discovery
  */
+const { EventEmitter } = require('events');
 const { RedisPubSub } = require('./redis-pubsub');
 const { logger } = require('./logger');
 
-class A2AAdapter {
+class A2AAdapter extends EventEmitter {
   constructor(options = {}) {
+    super();
     this.pubsub = options.pubsub || null;
     this.agentId = options.agentId || 'hub';
     this.messageTypes = ['task', 'result', 'error', 'heartbeat', 'handoff', 'negotiate', 'ack'];
@@ -162,6 +164,18 @@ class A2AAdapter {
     // Best-effort periodic pull from Redis to avoid local/remote drift.
     if (message.type === 'heartbeat' || message.type === 'result') {
       this.syncRegistryFromRedis().catch(() => {});
+    }
+
+    // Artifact availability notification from SharedStore.
+    // Emit as an event so hub/workers can subscribe without coupling to handleMessage.
+    if (message.type === 'artifact_ready') {
+      logger.info('a2a', `Artifact ready: ${message.artifactId}`, {
+        artifactId: message.artifactId,
+        agentId: message.agentId,
+        tags: message.tags
+      });
+      this.emit('artifact_ready', message);
+      return;
     }
 
     this.handleMessage(message);

--- a/src/shared-store.js
+++ b/src/shared-store.js
@@ -55,7 +55,7 @@ class SharedStore extends ArtifactStore {
         artifactId,
         agentId,
         filename,
-        tags: metadata.tags || [],
+        tags: Array.isArray(metadata.tags) ? metadata.tags : [],
         taskId: metadata.taskId || null,
         timestamp: new Date().toISOString()
       });

--- a/src/shared-store.js
+++ b/src/shared-store.js
@@ -60,7 +60,11 @@ class SharedStore extends ArtifactStore {
         timestamp: new Date().toISOString()
       });
       // Fire-and-forget: storage write already succeeded; notification failure is non-fatal.
-      this.redis.publish(ARTIFACT_NOTIFY_CHANNEL, notification).catch(() => {});
+      // Promise.resolve() normalises both Promise-returning and sync clients; the outer
+      // try/catch guards against a client whose publish() throws synchronously.
+      try {
+        Promise.resolve(this.redis.publish(ARTIFACT_NOTIFY_CHANNEL, notification)).catch(() => {});
+      } catch (_) {}
     }
 
     return artifactId;
@@ -106,9 +110,16 @@ class SharedStore extends ArtifactStore {
 function matchesQuery(manifest, query) {
   const meta = manifest.metadata || {};
 
-  if (query.tags && query.tags.length > 0) {
-    const manifestTags = meta.tags || [];
-    if (!query.tags.every(t => manifestTags.includes(t))) return false;
+  // Exact agentId match — listArtifacts() uses a prefix filter so 'agent' would
+  // otherwise also return artifacts from 'agent-1'. Re-check the manifest field.
+  if (query.agentId !== undefined && manifest.agentId !== query.agentId) return false;
+
+  if (query.tags !== undefined) {
+    if (!Array.isArray(query.tags)) return false;
+    if (query.tags.length > 0) {
+      const manifestTags = Array.isArray(meta.tags) ? meta.tags : [];
+      if (!query.tags.every(t => manifestTags.includes(t))) return false;
+    }
   }
 
   if (query.taskId !== undefined && meta.taskId !== query.taskId) return false;

--- a/src/shared-store.js
+++ b/src/shared-store.js
@@ -1,0 +1,121 @@
+/**
+ * SharedStore — cross-agent artifact sharing
+ *
+ * Extends ArtifactStore with two additions:
+ *
+ *   1. find(query)  — scan manifests and filter by metadata fields
+ *                     (agentId, tags, taskId, type, filename)
+ *
+ *   2. Redis pub/sub notification — when a Redis client is injected,
+ *      writeArtifact() publishes an `artifact_ready` event to the
+ *      `a2a:agents` broadcast channel so other workers can react.
+ *      The notification is fire-and-forget; a publish failure never
+ *      blocks or fails the write.
+ *
+ * Usage in workers:
+ *   const store = new SharedStore({ redis: this.redis });
+ *   const id = store.writeArtifact(agentId, 'result.json', data, { tags: ['coding'] });
+ *   // → publishes { type: 'artifact_ready', artifactId: id, ... } to a2a:agents
+ *
+ *   const matches = store.find({ tags: ['coding'], taskId: 'task-123' });
+ *
+ * Configuration:
+ *   SHARED_ARTIFACT_PATH env var (default: ./shared/artifacts)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { ArtifactStore } = require('./artifact-store');
+
+const ARTIFACT_NOTIFY_CHANNEL = 'a2a:agents';
+
+class SharedStore extends ArtifactStore {
+  constructor(options = {}) {
+    super(options);
+    // Optional Redis client — enables artifact_ready notifications.
+    // Set after connect() so tests can inject mocks without a live connection.
+    this.redis = options.redis || null;
+  }
+
+  /**
+   * Write an artifact and publish an artifact_ready notification.
+   *
+   * @param {string} agentId
+   * @param {string} filename
+   * @param {string|Buffer} content
+   * @param {object} metadata    - Arbitrary; `tags`, `taskId`, `type` are queryable
+   * @returns {string} artifactId
+   */
+  writeArtifact(agentId, filename, content, metadata = {}) {
+    const artifactId = super.writeArtifact(agentId, filename, content, metadata);
+
+    if (this.redis) {
+      const notification = JSON.stringify({
+        type: 'artifact_ready',
+        artifactId,
+        agentId,
+        filename,
+        tags: metadata.tags || [],
+        taskId: metadata.taskId || null,
+        timestamp: new Date().toISOString()
+      });
+      // Fire-and-forget: storage write already succeeded; notification failure is non-fatal.
+      this.redis.publish(ARTIFACT_NOTIFY_CHANNEL, notification).catch(() => {});
+    }
+
+    return artifactId;
+  }
+
+  /**
+   * Find artifacts matching a query.
+   *
+   * Supported query fields (all optional, AND-combined):
+   *   agentId  {string}   — prefix-filter via listArtifacts()
+   *   tags     {string[]} — manifest.metadata.tags must include ALL listed tags
+   *   taskId   {string}   — manifest.metadata.taskId must match exactly
+   *   type     {string}   — manifest.metadata.type must match exactly
+   *   filename {string}   — manifest.filename must match exactly
+   *
+   * @param {object} query
+   * @returns {object[]} array of manifest objects for matching artifacts
+   */
+  find(query = {}) {
+    const ids = this.listArtifacts(query.agentId);
+
+    return ids.reduce((acc, id) => {
+      const manifestPath = path.join(this.basePath, id, 'manifest.json');
+      let manifest;
+      try {
+        manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      } catch (_) {
+        return acc; // Skip unreadable manifests
+      }
+
+      if (!matchesQuery(manifest, query)) return acc;
+      acc.push(manifest);
+      return acc;
+    }, []);
+  }
+}
+
+/**
+ * Returns true when a manifest satisfies all non-empty query fields.
+ * @param {object} manifest
+ * @param {object} query
+ */
+function matchesQuery(manifest, query) {
+  const meta = manifest.metadata || {};
+
+  if (query.tags && query.tags.length > 0) {
+    const manifestTags = meta.tags || [];
+    if (!query.tags.every(t => manifestTags.includes(t))) return false;
+  }
+
+  if (query.taskId !== undefined && meta.taskId !== query.taskId) return false;
+  if (query.type   !== undefined && meta.type   !== query.type)   return false;
+  if (query.filename !== undefined && manifest.filename !== query.filename) return false;
+
+  return true;
+}
+
+module.exports = { SharedStore };

--- a/test/unit/shared-store.test.js
+++ b/test/unit/shared-store.test.js
@@ -86,6 +86,18 @@ describe('SharedStore.writeArtifact() — artifact_ready notification', () => {
     } finally { cleanup(tmpDir); }
   });
 
+  test('publish normalizes non-array tags to [] in the notification payload', () => {
+    // Regression: metadata.tags || [] passes through truthy non-arrays (e.g. a string).
+    // The artifact_ready payload must always carry tags as string[].
+    const mockRedis = { publish: vi.fn().mockResolvedValue(1) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      store.writeArtifact('worker-a', 'f.txt', 'x', { tags: 'coding' });
+      const [, raw] = mockRedis.publish.mock.calls[0];
+      expect(JSON.parse(raw).tags).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+
   test('does NOT publish when redis is null', () => {
     const { store, tmpDir } = makeTmpStore(null);
     try {

--- a/test/unit/shared-store.test.js
+++ b/test/unit/shared-store.test.js
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for SharedStore (src/shared-store.js)
+ *
+ * Uses a real temp directory — same pattern as artifact-store.test.js —
+ * so the fs layer is exercised without mocking.
+ */
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+const { SharedStore } = require('../../src/shared-store');
+
+function makeTmpStore(redis = null) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-store-test-'));
+  const store = new SharedStore({ basePath: tmpDir, redis });
+  return { store, tmpDir };
+}
+
+function cleanup(tmpDir) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ─── writeArtifact — inherited behaviour still works ─────────────────────────
+
+describe('SharedStore.writeArtifact() — inherited', () => {
+  test('returns a non-empty artifactId and creates manifest', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      const id = store.writeArtifact('worker-a', 'out.txt', 'hello');
+      expect(id).toBeTruthy();
+      const manifestPath = path.join(tmpDir, id, 'manifest.json');
+      expect(fs.existsSync(manifestPath)).toBe(true);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('readArtifact returns correct content and manifest', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      const id = store.writeArtifact('worker-a', 'data.json', '{"x":1}', { taskId: 'T1' });
+      const { content, manifest } = store.readArtifact(id);
+      expect(content.toString()).toBe('{"x":1}');
+      expect(manifest.metadata.taskId).toBe('T1');
+    } finally { cleanup(tmpDir); }
+  });
+});
+
+// ─── Redis pub/sub notification ───────────────────────────────────────────────
+
+describe('SharedStore.writeArtifact() — artifact_ready notification', () => {
+  test('publishes to a2a:agents when redis is injected', () => {
+    const mockRedis = { publish: vi.fn().mockResolvedValue(1) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      store.writeArtifact('worker-a', 'file.txt', 'content', { tags: ['coding'] });
+
+      expect(mockRedis.publish).toHaveBeenCalledOnce();
+      const [channel, raw] = mockRedis.publish.mock.calls[0];
+      expect(channel).toBe('a2a:agents');
+      const msg = JSON.parse(raw);
+      expect(msg.type).toBe('artifact_ready');
+      expect(msg.agentId).toBe('worker-a');
+      expect(msg.filename).toBe('file.txt');
+      expect(msg.tags).toEqual(['coding']);
+      expect(typeof msg.artifactId).toBe('string');
+      expect(typeof msg.timestamp).toBe('string');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('publish includes taskId from metadata', () => {
+    const mockRedis = { publish: vi.fn().mockResolvedValue(1) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      store.writeArtifact('worker-b', 'r.json', '{}', { taskId: 'task-99' });
+      const [, raw] = mockRedis.publish.mock.calls[0];
+      const msg = JSON.parse(raw);
+      expect(msg.taskId).toBe('task-99');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('publish sets tags to [] when metadata has no tags', () => {
+    const mockRedis = { publish: vi.fn().mockResolvedValue(1) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      store.writeArtifact('worker-c', 'x.txt', 'hi', {});
+      const [, raw] = mockRedis.publish.mock.calls[0];
+      expect(JSON.parse(raw).tags).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('does NOT publish when redis is null', () => {
+    const { store, tmpDir } = makeTmpStore(null);
+    try {
+      // Should not throw — just skips notification
+      expect(() => store.writeArtifact('worker-a', 'f.txt', 'x')).not.toThrow();
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('publish failure does not throw or fail the write', async () => {
+    const mockRedis = { publish: vi.fn().mockRejectedValue(new Error('Redis gone')) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      let id;
+      expect(() => { id = store.writeArtifact('worker-a', 'f.txt', 'x'); }).not.toThrow();
+      expect(id).toBeTruthy();
+      // Let the rejected promise flush — must not cause unhandled rejection
+      await Promise.resolve();
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('publish is called once per write', () => {
+    const mockRedis = { publish: vi.fn().mockResolvedValue(1) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      store.writeArtifact('a', '1.txt', 'x');
+      store.writeArtifact('b', '2.txt', 'y');
+      store.writeArtifact('c', '3.txt', 'z');
+      expect(mockRedis.publish).toHaveBeenCalledTimes(3);
+    } finally { cleanup(tmpDir); }
+  });
+});
+
+// ─── find() ──────────────────────────────────────────────────────────────────
+
+describe('SharedStore.find()', () => {
+  test('empty query returns all artifacts', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f1.txt', 'x', {});
+      store.writeArtifact('b', 'f2.txt', 'y', {});
+      const results = store.find({});
+      expect(results).toHaveLength(2);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by agentId returns only that agent\'s artifacts', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('agent-1', 'a.txt', 'x');
+      store.writeArtifact('agent-1', 'b.txt', 'y');
+      store.writeArtifact('agent-2', 'c.txt', 'z');
+      const results = store.find({ agentId: 'agent-1' });
+      expect(results).toHaveLength(2);
+      expect(results.every(m => m.agentId === 'agent-1')).toBe(true);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by single tag', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { tags: ['coding', 'output'] });
+      store.writeArtifact('b', 'g.txt', 'y', { tags: ['research'] });
+      const results = store.find({ tags: ['coding'] });
+      expect(results).toHaveLength(1);
+      expect(results[0].agentId).toBe('a');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by multiple tags requires all to be present', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { tags: ['coding', 'output'] });
+      store.writeArtifact('b', 'g.txt', 'y', { tags: ['coding'] });
+      // both have 'coding', only first has 'output'
+      expect(store.find({ tags: ['coding', 'output'] })).toHaveLength(1);
+      expect(store.find({ tags: ['coding'] })).toHaveLength(2);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by taskId', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { taskId: 'task-1' });
+      store.writeArtifact('b', 'g.txt', 'y', { taskId: 'task-2' });
+      const results = store.find({ taskId: 'task-1' });
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata.taskId).toBe('task-1');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by type', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { type: 'patch' });
+      store.writeArtifact('b', 'g.txt', 'y', { type: 'report' });
+      expect(store.find({ type: 'patch' })).toHaveLength(1);
+      expect(store.find({ type: 'report' })).toHaveLength(1);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find by filename', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'output.json', 'x');
+      store.writeArtifact('b', 'output.json', 'y');
+      store.writeArtifact('c', 'other.txt', 'z');
+      const results = store.find({ filename: 'output.json' });
+      expect(results).toHaveLength(2);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find combining agentId + tag + taskId', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('worker-a', 'f.txt', 'x', { tags: ['coding'], taskId: 'T1' });
+      store.writeArtifact('worker-a', 'g.txt', 'y', { tags: ['coding'], taskId: 'T2' });
+      store.writeArtifact('worker-b', 'h.txt', 'z', { tags: ['coding'], taskId: 'T1' });
+      const results = store.find({ agentId: 'worker-a', tags: ['coding'], taskId: 'T1' });
+      expect(results).toHaveLength(1);
+      expect(results[0].agentId).toBe('worker-a');
+      expect(results[0].metadata.taskId).toBe('T1');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find returns empty array when no artifacts match', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { tags: ['coding'] });
+      expect(store.find({ tags: ['research'] })).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find returns empty array on empty store', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      expect(store.find({})).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find silently skips artifacts with unreadable manifests', () => {
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      const id = store.writeArtifact('a', 'f.txt', 'x');
+      // Corrupt the manifest
+      fs.writeFileSync(path.join(tmpDir, id, 'manifest.json'), 'not-json{{{');
+      // Should not throw — just skips the bad entry
+      expect(() => store.find({})).not.toThrow();
+      expect(store.find({})).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+});

--- a/test/unit/shared-store.test.js
+++ b/test/unit/shared-store.test.js
@@ -94,7 +94,7 @@ describe('SharedStore.writeArtifact() — artifact_ready notification', () => {
     } finally { cleanup(tmpDir); }
   });
 
-  test('publish failure does not throw or fail the write', async () => {
+  test('publish failure does not throw or fail the write (async rejection)', async () => {
     const mockRedis = { publish: vi.fn().mockRejectedValue(new Error('Redis gone')) };
     const { store, tmpDir } = makeTmpStore(mockRedis);
     try {
@@ -103,6 +103,18 @@ describe('SharedStore.writeArtifact() — artifact_ready notification', () => {
       expect(id).toBeTruthy();
       // Let the rejected promise flush — must not cause unhandled rejection
       await Promise.resolve();
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('publish failure does not throw or fail the write (sync throw)', () => {
+    // Guards against a Redis client whose publish() throws synchronously
+    // (callback-based clients, or a client that returns a non-Promise value).
+    const mockRedis = { publish: vi.fn(() => { throw new Error('sync boom'); }) };
+    const { store, tmpDir } = makeTmpStore(mockRedis);
+    try {
+      let id;
+      expect(() => { id = store.writeArtifact('worker-a', 'f.txt', 'x'); }).not.toThrow();
+      expect(id).toBeTruthy();
     } finally { cleanup(tmpDir); }
   });
 
@@ -234,6 +246,29 @@ describe('SharedStore.find()', () => {
       // Should not throw — just skips the bad entry
       expect(() => store.find({})).not.toThrow();
       expect(store.find({})).toEqual([]);
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find({ agentId }) does not return artifacts from agents whose ID shares a prefix', () => {
+    // Regression: listArtifacts('agent') prefix-matches 'agent-1-...' artifact IDs.
+    // matchesQuery must re-check manifest.agentId for exact equality.
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('agent', 'a.txt', 'x');
+      store.writeArtifact('agent-1', 'b.txt', 'y');
+      const results = store.find({ agentId: 'agent' });
+      expect(results).toHaveLength(1);
+      expect(results[0].agentId).toBe('agent');
+    } finally { cleanup(tmpDir); }
+  });
+
+  test('find({ tags: <string> }) returns empty array without throwing', () => {
+    // Regression: passing a string instead of string[] must not crash via .every().
+    const { store, tmpDir } = makeTmpStore();
+    try {
+      store.writeArtifact('a', 'f.txt', 'x', { tags: ['coding'] });
+      expect(() => store.find({ tags: 'coding' })).not.toThrow();
+      expect(store.find({ tags: 'coding' })).toEqual([]);
     } finally { cleanup(tmpDir); }
   });
 });

--- a/workers/base-worker.js
+++ b/workers/base-worker.js
@@ -4,7 +4,7 @@
  */
 
 const EventEmitter = require('events');
-const { ArtifactStore } = require('../src/artifact-store');
+const { SharedStore } = require('../src/shared-store');
 const { logger } = require('../src/logger');
 
 // Fixed TTL for the shared a2a:registry hash key.
@@ -31,7 +31,7 @@ class BaseWorker extends EventEmitter {
     this.currentTask = null;
     this.startTime = null;
 
-    this.artifacts = options.artifactStore || new ArtifactStore();
+    this.artifacts = options.artifactStore || new SharedStore();
   }
 
   /**
@@ -43,6 +43,10 @@ class BaseWorker extends EventEmitter {
       host: process.env.REDIS_HOST || 'redis',
       port: process.env.REDIS_PORT || 6379
     });
+    // Wire live Redis into SharedStore so artifact_ready notifications are published.
+    if (this.artifacts instanceof SharedStore) {
+      this.artifacts.redis = this.redis;
+    }
     logger.info(this.agentId, 'Connecting to Redis');
   }
 


### PR DESCRIPTION
## Summary

- **`src/shared-store.js`** — `SharedStore` extends `ArtifactStore` with two new capabilities:
  - `find({ agentId, tags, taskId, type, filename })` — scans manifests and returns matching artifacts; all query fields are optional and AND-combined
  - Fire-and-forget Redis pub/sub notification on every `writeArtifact()` call: publishes `{ type: 'artifact_ready', artifactId, agentId, filename, tags, taskId }` to `a2a:agents`
- **`workers/base-worker.js`** — replaces `ArtifactStore` with `SharedStore`; wires live Redis into the store after `connect()` so notifications go out automatically
- **`src/a2a-adapter.js`** — adds `EventEmitter` inheritance; handles `artifact_ready` in `handleBroadcast()` (logs + re-emits as Node.js event for hub/worker subscribers)
- **`test/unit/shared-store.test.js`** — 19 tests; `shared-store.js` at 100% statement/function/line coverage
- **`docs/BACKLOG.md`** — marks the `shared/` backlog item as done
- **`CLAUDE.md`** — updates Shared artifacts architecture section

## Design decisions

- Extends rather than wraps `ArtifactStore` — purely additive, no existing call-sites change
- Notifications are fire-and-forget — a Redis publish failure never blocks or fails the storage write
- No new Redis channels — reuses the existing `a2a:agents` broadcast channel
- No dispatcher changes needed — artifact routing travels on pub/sub, not the task queue

## Test plan

- [x] `docker exec openclaw-coordination-hub npm test` — all 301 tests pass
- [x] `docker exec openclaw-coordination-hub npm run test:coverage` — `shared-store.js` at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)